### PR TITLE
remove (string) cast on $dependenciesIdentifier at setDependenciesIdentifier()

### DIFF
--- a/src/ZendModuleProvider.php
+++ b/src/ZendModuleProvider.php
@@ -119,7 +119,7 @@ class ZendModuleProvider
 
     public function setDependenciesIdentifier(string $dependenciesIdentifier) : void
     {
-        $this->dependenciesIdentifier = (string) $dependenciesIdentifier;
+        $this->dependenciesIdentifier = $dependenciesIdentifier;
     }
 
     private function getModuleDependencies() : array


### PR DESCRIPTION
as function parameter already use `string` type.

- [x] Is this related to quality assurance?
